### PR TITLE
Support for LOCAL_CODE and triggers in gitolite.rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ None.
 * ``gitolite_gitoliterc_shell_user_list``: Configure gitolite.rc, SHELL_USER_LIST option (default: ``[]``)
 * ``gitolite_gitoliterc_roles``: Configure gitolite.rc, ROLES option (default: ``["READERS", "WRITERS"]``)
 * ``gitolite_gitoliterc_enable_features``: Configure gitolite.rc, ENABLE option (default: ``["help", "desc", "info", "perms", "writable", "ssh-authkeys", "git-config", "daemon", "gitweb"]``)
+* ``gitolite_gitoliterc_local_code``: Configure gitolite.rc, LOCAL_CODE option (default: "")
+* ``gitolite_gitoliterc_triggers``: Configure gitolite.rc triggers (default: {}). Must be a dictionary of lists, with key name as trigger (eg. ``{post_compile: ['my-custom-post-compile']}``)
 
 ### gitolite.conf configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,12 @@ gitolite_gitoliterc_shell_user_list: []
 #   gitolite roles.
 gitolite_gitoliterc_roles: ['READERS', 'WRITERS']
 
+#   gitolite LOCAL CODE
+gitolite_gitoliterc_local_code: ''
+
+#   gitolite custom triggers
+gitolite_gitoliterc_triggers: {}
+
 #   features to enable
 gitolite_gitoliterc_enable_features:
   - help

--- a/templates/gitolite.rc.j2
+++ b/templates/gitolite.rc.j2
@@ -44,6 +44,14 @@
 {% endfor %}
   },
 
+{% if gitolite_gitoliterc_local_code != '' %}
+  LOCAL_CODE => '{{ gitolite_gitoliterc_local_code }}',
+{%- endif %}
+
+{% for trigger, scripts in gitolite_gitoliterc_triggers.iteritems() %}{% if scripts|count > 0 %}
+  {{ trigger|upper }} => ['{{ scripts|join("', '") }}'],
+{% endif %}{% endfor %}
+
   ENABLE => [
 {% for feature in gitolite_gitoliterc_enable_features %}
     '{{ feature }}',


### PR DESCRIPTION
Hi,

I have added support for defining `LOCAL_CODE` and triggers (eg. `POST_COMPILE`, `POST_CREATE`).
Also I've added documentation for `gitolite_mirroring_peers`, `gitolite_gitoliterc_local_code` and `gitolite_gitoliterc_triggers`.

Can you please review this PR.
