### PR TITLE
Fix bug "AnsibleUndefinedVariable: 'create_repo' is undefined"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This role installs and configures gitolite from upstream Git repository.
   vars:
     gitolite_repositories_custom:
       - repo: toast
-        admin: ["id_rsa", "{{ gitolite_user_name }}"]
+        admin:
+          users: ["id_rsa", "{{ gitolite_user_name }}"]
   roles:
     - ansible-gitolite
 ```

--- a/templates/gitolite.conf.j2
+++ b/templates/gitolite.conf.j2
@@ -54,18 +54,21 @@ repo {{ r.repo }}
 
 {% macro iter_repos(repositories) -%}
 {% for repo in repositories -%}
+{% with -%}
+{% set valid_rules = [] -%}
 {% for ace in ('admin', 'write', 'read') -%}
 {% if ace in repo -%}
 {% for arg in ('options', 'users') -%}
 {% if arg in repo[ace] -%}
-{% set create_repo = true -%}
+{% if valid_rules.append('') %}{% endif %}
 {%- endif %}
 {%- endfor %}
 {%- endif %}
 {%- endfor %}
-{% if create_repo -%}
+{% if valid_rules|length > 0 -%}
 {{ gitolite_repo(repo) }}
 {%- endif %}
+{%- endwith %}
 {%- endfor %}
 {%- endmacro %}
 

--- a/templates/gitolite.conf.j2
+++ b/templates/gitolite.conf.j2
@@ -17,6 +17,8 @@ repo {{ r.repo }}
 {% if 'admin' in r and r['admin']|count > 0 -%}
 {% if 'users' in r['admin'] and r['admin']['users']|count > 0 -%}
 {% set perma = "  RW+ = " + r['admin']['users']|join(" ") -%}
+{% else -%}
+{% set perma = "" -%}
 {%- endif %}
 {% if perma|count > 0 -%}
 {{ perma }}


### PR DESCRIPTION
Hello, I have fixed this bug, please review it. thanks.

Error messages:

```bash
TASK [silpion.gitolite : Install gitolite.conf] ***************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ (gitolite_repositories +
gitolite_repositories_custom)|count != 0 }}

 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ not
gitolite_fact_initial_checkmod|default(false) }}

fatal: [txg_stg]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'create_repo' is undefined"}
```
Ansible version:

```bash
$ ansible --version
ansible 2.4.0.0
  config file = /path/ansible/ansible.cfg
  configured module search path = [u'/path/ansible/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```
